### PR TITLE
Add DAO tests using H2 database

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,5 +34,32 @@
             <artifactId>logback-classic</artifactId>
             <version>1.4.14</version>
         </dependency>
+
+        <!-- Testing dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.2.224</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/test/java/com/example/userservice/dao/UserDaoImplTest.java
+++ b/src/test/java/com/example/userservice/dao/UserDaoImplTest.java
@@ -1,0 +1,85 @@
+package com.example.userservice.dao;
+
+import com.example.userservice.model.User;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class UserDaoImplTest {
+    private UserDaoImpl dao;
+
+    @BeforeEach
+    void setUp() {
+        dao = new UserDaoImpl();
+    }
+
+    @AfterEach
+    void tearDown() {
+        // nothing to close - SessionFactory closes with JVM shutdown
+    }
+
+    @Test
+    void testSaveAndGetById() {
+        User user = new User("John", "john@example.com", 30, LocalDateTime.now());
+        dao.save(user);
+        assertNotNull(user.getId());
+
+        User loaded = dao.findById(user.getId());
+        assertNotNull(loaded);
+        assertEquals(user.getName(), loaded.getName());
+        assertEquals(user.getEmail(), loaded.getEmail());
+        assertEquals(user.getAge(), loaded.getAge());
+    }
+
+    @Test
+    void testGetAll() {
+        User user1 = new User("Alice", "alice@example.com", 25, LocalDateTime.now());
+        User user2 = new User("Bob", "bob@example.com", 35, LocalDateTime.now());
+        dao.save(user1);
+        dao.save(user2);
+
+        // access internal SessionFactory to query all users
+        org.hibernate.SessionFactory factory;
+        try {
+            Field field = UserDaoImpl.class.getDeclaredField("sessionFactory");
+            field.setAccessible(true);
+            factory = (org.hibernate.SessionFactory) field.get(dao);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        try (org.hibernate.Session session = factory.openSession()) {
+            List<User> users = session.createQuery("from User", User.class).list();
+            assertEquals(2, users.size());
+        }
+    }
+
+    @Test
+    void testUpdate() {
+        User user = new User("Carl", "carl@example.com", 40, LocalDateTime.now());
+        dao.save(user);
+
+        user.setName("Carl Updated");
+        dao.update(user);
+
+        User loaded = dao.findById(user.getId());
+        assertEquals("Carl Updated", loaded.getName());
+    }
+
+    @Test
+    void testDelete() {
+        User user = new User("Dave", "dave@example.com", 22, LocalDateTime.now());
+        dao.save(user);
+        Long id = user.getId();
+
+        dao.deleteById(id);
+        User loaded = dao.findById(id);
+        assertNull(loaded);
+    }
+}

--- a/src/test/resources/hibernate.cfg.xml
+++ b/src/test/resources/hibernate.cfg.xml
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!DOCTYPE hibernate-configuration PUBLIC
+        "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
+        "http://hibernate.org/dtd/hibernate-configuration-3.0.dtd">
+<hibernate-configuration>
+    <session-factory>
+        <property name="hibernate.connection.driver_class">org.h2.Driver</property>
+        <property name="hibernate.connection.url">jdbc:h2:mem:test;DB_CLOSE_DELAY=-1</property>
+        <property name="hibernate.dialect">org.hibernate.dialect.H2Dialect</property>
+        <property name="hibernate.hbm2ddl.auto">create-drop</property>
+        <property name="hibernate.show_sql">false</property>
+        <property name="hibernate.format_sql">true</property>
+        <mapping class="com.example.userservice.model.User"/>
+    </session-factory>
+</hibernate-configuration>


### PR DESCRIPTION
## Summary
- add JUnit and H2 dependencies
- configure Maven Surefire plugin for tests
- create Hibernate config for tests using H2 in-memory database
- add UserDaoImplTest verifying CRUD operations

## Testing
- `mvn test` *(fails: Could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68408fade0a4832288e90701324dcc20